### PR TITLE
Use a temporary location for temporary files

### DIFF
--- a/CODES/ILAMB_Main.sh
+++ b/CODES/ILAMB_Main.sh
@@ -36,8 +36,3 @@ export PLOTTYPE=png
 date
 ncl -n main_ncl_code.ncl
 date
-
-# Clean up temporary files.
-if [ -e $ILAMB_TMPDIR ]; then
-    rm -rf $ILAMB_TMPDIR
-fi

--- a/CODES/ILAMB_Main.sh
+++ b/CODES/ILAMB_Main.sh
@@ -11,10 +11,10 @@ export ILAMB_ROOT=`pwd`
 cd $ILAMB_CODESDIR
 
 # Allow a user to configure these directories.
-export ILAMB_DATADIR=$HOME/DATA
-export ILAMB_MODELSDIR=$HOME/MODELS
-export ILAMB_OUTPUTDIR=$HOME/OUTPUT
-export ILAMB_TMPDIR=/tmp/ILAMB
+export ILAMB_DATADIR=/home/ILAMB/DATA
+export ILAMB_MODELSDIR=/home/ILAMB/MODELS
+export ILAMB_OUTPUTDIR=/home/ILAMB/OUTPUT
+export ILAMB_TMPDIR=/home/ILAMB/tmp
 
 echo "ILAMB directories:"
 echo "ILAMB_ROOT      $ILAMB_ROOT"

--- a/CODES/ILAMB_Main.sh
+++ b/CODES/ILAMB_Main.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# ILAMB execution script.
+# A simple ILAMB execution script, useful for debugging.
 #
-# Run with:
+# From this directory, run with:
 #   $ bash ILAMB_Main.sh 1>stdout 2>stderr
 
 export ILAMB_CODESDIR=`pwd`
@@ -14,6 +14,7 @@ cd $ILAMB_CODESDIR
 export ILAMB_DATADIR=$HOME/DATA
 export ILAMB_MODELSDIR=$HOME/MODELS
 export ILAMB_OUTPUTDIR=$HOME/OUTPUT
+export ILAMB_TMPDIR=/tmp/ILAMB
 
 echo "ILAMB directories:"
 echo "ILAMB_ROOT      $ILAMB_ROOT"
@@ -21,6 +22,7 @@ echo "ILAMB_CODESDIR  $ILAMB_CODESDIR"
 echo "ILAMB_DATADIR   $ILAMB_DATADIR"
 echo "ILAMB_MODELSDIR $ILAMB_MODELSDIR"
 echo "ILAMB_OUTPUTDIR $ILAMB_OUTPUTDIR"
+echo "ILAMB_TMPDIR    $ILAMB_TMPDIR"
 
 ## Define model simulation type, CLM or CMIP5.
 export MODELTYPE=CMIP5
@@ -34,3 +36,8 @@ export PLOTTYPE=png
 date
 ncl -n main_ncl_code.ncl
 date
+
+# Clean up temporary files.
+if [ -e $ILAMB_TMPDIR ]; then
+    rm -rf $ILAMB_TMPDIR
+fi

--- a/CODES/main_ncl_code.ncl
+++ b/CODES/main_ncl_code.ncl
@@ -17,7 +17,7 @@ begin
   PlotType = str_lower(str_squeeze(PlotType))
 
   ; ++++ check if the sub directory tempfiles exists in INPUT, if not, create it ++++
-  TempDir = ILAMBDir + "/CODES/tempfiles"
+  TempDir = getenv("ILAMB_TMPDIR") + "/tempfiles"
 
   system ("csh -c 'if (! -d "+TempDir+") then; mkdir "+TempDir+"; end if'")
 

--- a/CODES/run_ilamb.sh
+++ b/CODES/run_ilamb.sh
@@ -39,6 +39,7 @@ export ILAMB_CODESDIR=$ILAMB_ROOT/CODES
 export ILAMB_DATADIR=$nas_dir/DATA
 export ILAMB_MODELSDIR=$nas_dir/MODELS
 export ILAMB_OUTPUTDIR=$tmp_dir/$output_name
+export ILAMB_TMPDIR=$tmp_dir/tmp_$job_id
 stdout_file=$ILAMB_OUTPUTDIR/ILAMB.stdout
 stderr_file=$ILAMB_OUTPUTDIR/ILAMB.stderr
 
@@ -57,10 +58,10 @@ tar zcf $tarfile -C $tmp_dir $output_name
 mv $tarfile $PBS_O_WORKDIR
 
 # Cleanup.
-to_remove="$stdout_file $stderr_file \
+to_remove="$stdout_file \
+    $stderr_file \
     $ILAMB_OUTPUTDIR \
-    $ILAMB_CODESDIR/temp.data \
-    $ILAMB_CODESDIR/tempfiles"
+    $ILAMB_TMPDIR"
 for item in $to_remove; do
     if [ -e $item ]; then
 	rm -rf $item

--- a/CODES/subroutines/check/check-allsubs.ncl
+++ b/CODES/subroutines/check/check-allsubs.ncl
@@ -369,10 +369,12 @@ do ns=0, nsit-1
 
   header = (/"Model", "Annual", "Bias", "RMSE"/)
 
-  write_table("temp.data","w",[/header(0),header(1),header(2),header(3)/], "%10s %9s %9s %9s")
-  write_table("temp.data","a",[/ModelNameList,anual(:,ns), bias(:,ns), rmse(:,ns)/], "%10s %9.2f %9.2f %9.2f")
+  temp_data_file = getenv("ILAMB_TMPDIR") + "/temp.data"
 
-  infos = asciiread("temp.data",-1,"string")
+  write_table(temp_data_file,"w",[/header(0),header(1),header(2),header(3)/], "%10s %9s %9s %9s")
+  write_table(temp_data_file,"a",[/ModelNameList,anual(:,ns), bias(:,ns), rmse(:,ns)/], "%10s %9.2f %9.2f %9.2f")
+
+  infos = asciiread(temp_data_file,-1,"string")
 
   Draw_TS_Check (PlotFileName, tta(:,nr,:), tts(:,nr,:), infos)
 
@@ -782,10 +784,12 @@ if (any(.not.ismissing(tts(:,ns,:)))) then
 
   header = (/"Model", "Annual", "Bias", "RMSE"/)
 
-  write_table("temp.data","w",[/header(0),header(1),header(2),header(3)/], "%10s %9s %9s %9s")
-  write_table("temp.data","a",[/ModelNameList,anual(:,ns), bias(:,ns), rmse(:,ns)/], "%10s %9.2f %9.2f %9.2f")
+  temp_data_file = getenv("ILAMB_TMPDIR") + "/temp.data"
 
-  infos = asciiread("temp.data",-1,"string")
+  write_table(temp_data_file,"w",[/header(0),header(1),header(2),header(3)/], "%10s %9s %9s %9s")
+  write_table(temp_data_file,"a",[/ModelNameList,anual(:,ns), bias(:,ns), rmse(:,ns)/], "%10s %9.2f %9.2f %9.2f")
+
+  infos = asciiread(temp_data_file,-1,"string")
 
   do nv = 0, nmod
      if (.not.ismissing(anual(0,ns))) then
@@ -1558,10 +1562,12 @@ do nv = 0, nmod
 
      header = (/"Model", "Annual", "Bias", "RMSE"/)
 
-     write_table("temp.data","w",[/header(0),header(1),header(2),header(3)/], "%10s %9s %9s %9s")
-     write_table("temp.data","a",[/ModelNameList,anual(:,nr), bias(:,nr), rmse(:,nr)/], "%10s %9.2f %9.2f %9.2f")
+     temp_data_file = getenv("ILAMB_TMPDIR") + "/temp.data"
 
-     infos = asciiread("temp.data",-1,"string")
+     write_table(temp_data_file,"w",[/header(0),header(1),header(2),header(3)/], "%10s %9s %9s %9s")
+     write_table(temp_data_file,"a",[/ModelNameList,anual(:,nr), bias(:,nr), rmse(:,nr)/], "%10s %9.2f %9.2f %9.2f")
+
+     infos = asciiread(temp_data_file,-1,"string")
 
      Draw_TS_Check (PlotFileName, tt1(:,nr,:), tt2(:,nr,:), infos)
 
@@ -2291,10 +2297,12 @@ do nv = 0, nmod
 
      header = (/"Model", "Annual", "Bias", "RMSE"/)
 
-     write_table("temp.data","w",[/header(0),header(1),header(2),header(3)/], "%10s %9s %9s %9s")
-     write_table("temp.data","a",[/ModelNameList,anual(:,nr), bias(:,nr), rmse(:,nr)/], "%10s %9.2f %9.2f %9.2f")
+     temp_data_file = getenv("ILAMB_TMPDIR") + "/temp.data"
 
-     infos = asciiread("temp.data",-1,"string")
+     write_table(temp_data_file,"w",[/header(0),header(1),header(2),header(3)/], "%10s %9s %9s %9s")
+     write_table(temp_data_file,"a",[/ModelNameList,anual(:,nr), bias(:,nr), rmse(:,nr)/], "%10s %9.2f %9.2f %9.2f")
+
+     infos = asciiread(temp_data_file,-1,"string")
 
      Draw_TS_Check (PlotFileName, tt1(:,nr,:), tt2(:,nr,:), infos)
 

--- a/CODES/subroutines/diagnostic/diagnostic-allsubs.ncl
+++ b/CODES/subroutines/diagnostic/diagnostic-allsubs.ncl
@@ -1112,10 +1112,12 @@ do nv = 0, nmod
 
      header = (/"Model", "Annual", "Bias", "RMSE"/)
 
-     write_table("temp.data","w",[/header(0),header(1),header(2),header(3)/], "%10s %9s %9s %9s")
-     write_table("temp.data","a",[/ModelNameList,anual(:,nr), bias(:,nr), rmse(:,nr)/], "%10s %9.2f %9.2f %9.2f")
+     temp_data_file = getenv("ILAMB_TMPDIR") + "/temp.data"
 
-     infos = asciiread("temp.data",-1,"string")
+     write_table(temp_data_file,"w",[/header(0),header(1),header(2),header(3)/], "%10s %9s %9s %9s")
+     write_table(temp_data_file,"a",[/ModelNameList,anual(:,nr), bias(:,nr), rmse(:,nr)/], "%10s %9.2f %9.2f %9.2f")
+
+     infos = asciiread(temp_data_file,-1,"string")
 
      Draw_TS_Check (PlotFileName, tt1(:,nr,:), tt2(:,nr,:), infos)
 

--- a/CODES/subroutines/diagnostic/input_control_para.ncl
+++ b/CODES/subroutines/diagnostic/input_control_para.ncl
@@ -502,7 +502,7 @@ do nv = 0, nvar - 1
          runID  = where(nrun.eq.0, 0, runID)
          runID  = where(cmipID.eq.0, 0, runID)
 
-         TableFileName = ILAMBDir + "/CODES/tempfiles/input_para_" + str_lower(VarObs) + "_" + str_upper(Source)
+         TableFileName = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_" + str_lower(VarObs) + "_" + str_upper(Source)
 
          header=new((/16/), string)
 
@@ -596,7 +596,7 @@ nvpa = nk
 do nk =0, nvpa-1
 
   ;++++ input the control parameters for the 1st variable ++++
-  TableFileName1 = ILAMBDir + "/CODES/tempfiles/input_para_" + str_lower(Vars1(nk)) + "_" + str_upper(Sources1(nk))
+  TableFileName1 = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_" + str_lower(Vars1(nk)) + "_" + str_upper(Sources1(nk))
 
   data_1d = asciiread(str_squeeze(TableFileName1),-1,"string")
 
@@ -621,7 +621,7 @@ do nk =0, nvpa-1
   nmod          = dimsizes(ModelNames)-1
 
   ;++++ input the control parameters for the 2nd variable ++++
-  TableFileName2 = ILAMBDir + "/CODES/tempfiles/input_para_" + str_lower(Vars2(nk)) + "_" + str_upper(Sources2(nk))
+  TableFileName2 = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_" + str_lower(Vars2(nk)) + "_" + str_upper(Sources2(nk))
 
   data_1d = asciiread(str_squeeze(TableFileName2),-1,"string")
 
@@ -687,7 +687,7 @@ do nk =0, nvpa-1
   header(25) = "                                       "
   header(26)= "      Model Name" + "      cmipID  " + " runID "
 
-  TableFileName = ILAMBDir + "/CODES/tempfiles/input_para_pair" + sprinti("%0.2i",nk+1)
+  TableFileName = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_pair" + sprinti("%0.2i",nk+1)
 
   write_table(TableFileName, "w", [/header/], "%s")
   write_table(TableFileName,"a",[/ModelNames,cmipID,runID/], "%16s %8i %7i")
@@ -709,7 +709,7 @@ end if
 do nck =0, nchk-1
 
   ;++++ input the control parameters for variables ++++
-  TableFileName = ILAMBDir + "/CODES/tempfiles/input_para_" + str_lower(VarNameCheck(nck)) + "_" + str_upper(SourcesCheck(nck))
+  TableFileName = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_" + str_lower(VarNameCheck(nck)) + "_" + str_upper(SourcesCheck(nck))
   print(TableFileName)
 
   data_1d = asciiread(str_squeeze(TableFileName),-1,"string")
@@ -760,7 +760,7 @@ do nck =0, nchk-1
   header(13) = "                                                                                               "
   header(14) = "      Model Name" + "     cmipID  " + " runID "
 
-  TableFileName = ILAMBDir + "/CODES/tempfiles/input_para_check" + sprinti("%0.2i",nck+1)
+  TableFileName = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_check" + sprinti("%0.2i",nck+1)
 
   write_table(TableFileName, "w", [/header/], "%s")
   write_table(TableFileName,"a",[/ModelNames,cmipID,runID/], "%16s %8i %7i")

--- a/CODES/subroutines/diagnostic/run_diagnostics.ncl
+++ b/CODES/subroutines/diagnostic/run_diagnostics.ncl
@@ -19,7 +19,7 @@ print("                                                                       ")
 print("--->--->--->--->--->--->--->--->--->--->--->--->--->--->--->--->--->--->")
 print("Searching All Data Sources for the Variable: " + VarName)
 
-InputFiles = DataDir + "/CODES/tempfiles/input_para_" + str_lower(VarName)
+InputFiles = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_" + str_lower(VarName)
 
 FileList = systemfunc ("ls " + InputFiles + "*")
 
@@ -69,7 +69,7 @@ nKeyWords   = 0
 
 do ns=0,nsur-1
 
-  TableFileName = DataDir + "/CODES/tempfiles/input_para_" + str_lower(VarName) + "_" + str_upper(Sources(ns))
+  TableFileName = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_" + str_lower(VarName) + "_" + str_upper(Sources(ns))
 
   data_1d = asciiread(str_squeeze(TableFileName),-1,"string")
   ;print(data_1d)

--- a/CODES/subroutines/diagnostic/run_func_pair.ncl
+++ b/CODES/subroutines/diagnostic/run_func_pair.ncl
@@ -20,7 +20,7 @@ begin
 
 ; ++++++ input control parameters from a file: ../CODES/tempfiles/input_para_pair* +++++
 
-  TableFileName = DataDir + "/CODES/tempfiles/input_para_pair" + sprinti("%0.2i",nvpa)
+  TableFileName = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_pair" + sprinti("%0.2i",nvpa)
 
   data_1d = asciiread(str_squeeze(TableFileName),-1,"string")
   ;print(data_1d)

--- a/CODES/subroutines/diagnostic/run_point_check.ncl
+++ b/CODES/subroutines/diagnostic/run_point_check.ncl
@@ -15,7 +15,7 @@ begin
 
 ; ++++++ input control parameters from a file: ../CODES/tempfiles/input_para_check* +++++
 
-  TableFileName = DataDir + "/CODES/tempfiles/input_para_check" + sprinti("%0.2i",nck)
+  TableFileName = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_check" + sprinti("%0.2i",nck)
 
   data_1d = asciiread(str_squeeze(TableFileName),-1,"string")
   ;print(data_1d)

--- a/CODES/subroutines/general/initialization.ncl
+++ b/CODES/subroutines/general/initialization.ncl
@@ -66,7 +66,7 @@ delete(VarDirList)
 
 if (str_lower(FileType).eq."all") then
 
-   TempDir = ILAMBDir + "/CODES/tempfiles"
+   TempDir = getenv("ILAMB_TMPDIR") + "/tempfiles"
 
    system ("/bin/rm -f " + TempDir + "/*")
 

--- a/CODES/subroutines/publish/publish-allsubs.ncl
+++ b/CODES/subroutines/publish/publish-allsubs.ncl
@@ -1147,7 +1147,7 @@ if (nck.ge.1) then
 
    ;++++ read data from saved files ++++
 
-   FileName1 = DataDir + "/CODES/tempfiles/input_para_check" + sprinti("%0.2i",nck)
+   FileName1 = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_check" + sprinti("%0.2i",nck)
    print(FileName1)
 
    data_1d  = asciiread(str_squeeze(FileName1),-1,"string")
@@ -2850,7 +2850,7 @@ nkeys     = 0
 
 do nv = 0, nvar-1
 
-   InputFiles = DataDir + "/CODES/tempfiles/input_para_" + str_lower(VarNames(nv))
+   InputFiles = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_" + str_lower(VarNames(nv))
 
    FileList = systemfunc ("ls " + InputFiles + "*")
 
@@ -2946,7 +2946,7 @@ do nv = 0, nvar-1
    print("--->--->--->--->--->--->--->--->--->--->--->--->--->--->--->--->--->--->")
    print("Searching All Data Sources for the Variable: " + VarNames(nv))
 
-   InputFiles = DataDir + "/CODES/tempfiles/input_para_" + str_lower(VarNames(nv))
+   InputFiles = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_" + str_lower(VarNames(nv))
 
    FileList = systemfunc ("ls " + InputFiles + "*")
 
@@ -2983,7 +2983,7 @@ do nv = 0, nvar-1
          delete(Sourcet0)
          delete(Sourcet1)
 
-         TableFileName = DataDir + "/CODES/tempfiles/input_para_" + str_lower(VarNames(nv)) + "_" + str_upper(Source)
+         TableFileName = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_" + str_lower(VarNames(nv)) + "_" + str_upper(Source)
 
          data_1d = asciiread(str_squeeze(TableFileName),-1,"string")
 
@@ -3037,7 +3037,7 @@ do nv = 0, nvar-1
       delete(Sourcet0)
       delete(Sourcet1)
 
-      TableFileName = DataDir + "/CODES/tempfiles/input_para_" + str_lower(VarNames(nv)) + "_" + str_upper(Source)
+      TableFileName = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_" + str_lower(VarNames(nv)) + "_" + str_upper(Source)
       data_1d = asciiread(str_squeeze(TableFileName),-1,"string")
 
       KeyWord0     = str_get_field(data_1d(13), 2, ":")
@@ -3573,7 +3573,7 @@ nmodx = 0
 
 do nvp =0, nvpa-1
 
-  FileName = DataDir + "/CODES/tempfiles/input_para_pair" + sprinti("%0.2i",nvp+1)
+  FileName = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_pair" + sprinti("%0.2i",nvp+1)
   print(FileName)
 
   data_1d  = asciiread(str_squeeze(FileName),-1,"string")
@@ -3986,7 +3986,7 @@ VarListSite    = new((/nvar/), string)
 SourceListSite = new((/nvar/), string)
 
 do nck =0, nchk-1
-   FileName1 = DataDir + "/CODES/tempfiles/input_para_check" + sprinti("%0.2i",nck+1)
+   FileName1 = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_check" + sprinti("%0.2i",nck+1)
    print(FileName1)
 
    data_1d  = asciiread(str_squeeze(FileName1),-1,"string")
@@ -4024,7 +4024,7 @@ do nv=0,nvar-1
    print("--->--->--->--->--->--->--->--->--->--->--->--->--->--->--->--->--->--->")
    print("Searching All Data Sources for the Variable: " + VarName)
 
-   InputFiles = DataDir + "/CODES/tempfiles/input_para_" + str_lower(VarName)
+   InputFiles = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_" + str_lower(VarName)
 
    FileList = systemfunc ("ls " + InputFiles + "*")
 
@@ -4096,7 +4096,7 @@ do nv=0,nvar-1
 
    do ns=0,nsur-1
 
-      TableFileName= DataDir + "/CODES/tempfiles/input_para_" + str_lower(VarName) + "_" + str_upper(Sources(ns))
+      TableFileName= getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_" + str_lower(VarName) + "_" + str_upper(Sources(ns))
 
       data_1d      = asciiread(TableFileName,-1,"string")
 

--- a/CODES/subroutines/relationships/relationship-allsubs.ncl
+++ b/CODES/subroutines/relationships/relationship-allsubs.ncl
@@ -1530,7 +1530,7 @@ EE0       = constants@EulerNumb
 
 do nvp =1, nvpa
 
-  ControlFileName = DataDir + "/CODES/tempfiles/input_para_pair" + sprinti("%0.2i",nvp)
+  ControlFileName = getenv("ILAMB_TMPDIR") + "/tempfiles/input_para_pair" + sprinti("%0.2i",nvp)
 
   data_1d = asciiread(str_squeeze(ControlFileName),-1,"string")
 


### PR DESCRIPTION
ILAMB creates the the directory **tempfiles** and the file **temp.data** within its **CODES** directory. This causes problems if more than one person is running ILAMB on **_beach**_. I created a new environment variable, `ILAMB_TMPDIR`, set it to an appropriate location on the filesystem, and made ILAMB's temporary file and directory there. 
