### PR TITLE
Pass ILAMB parameter file as a parameter

### DIFF
--- a/CODES/ILAMB_Main.sh
+++ b/CODES/ILAMB_Main.sh
@@ -3,7 +3,12 @@
 # A simple ILAMB execution script, useful for debugging.
 #
 # From this directory, run with:
-#   $ bash ILAMB_Main.sh 1>stdout 2>stderr
+#   $ bash ILAMB_Main.sh /path/to/ILAMB_PARA_SETUP 1>stdout 2>stderr &
+
+if [ -z "$1" ]; then
+    echo "Error: Must supply path to ILAMB parameter file"
+    exit 1
+fi
 
 export ILAMB_CODESDIR=`pwd`
 cd ..
@@ -11,18 +16,19 @@ export ILAMB_ROOT=`pwd`
 cd $ILAMB_CODESDIR
 
 # Allow a user to configure these directories.
-export ILAMB_DATADIR=/home/ILAMB/DATA
-export ILAMB_MODELSDIR=/home/ILAMB/MODELS
-export ILAMB_OUTPUTDIR=/home/ILAMB/OUTPUT
-export ILAMB_TMPDIR=/home/ILAMB/tmp
+export ILAMB_DATADIR=/nas/data/ILAMB/DATA
+export ILAMB_MODELSDIR=/nas/data/ILAMB/MODELS
+export ILAMB_OUTPUTDIR=/nas/data/ILAMB/tmp/OUTPUT
+export ILAMB_TMPDIR=/nas/data/ILAMB/tmp
 
-echo "ILAMB directories:"
-echo "ILAMB_ROOT      $ILAMB_ROOT"
-echo "ILAMB_CODESDIR  $ILAMB_CODESDIR"
-echo "ILAMB_DATADIR   $ILAMB_DATADIR"
-echo "ILAMB_MODELSDIR $ILAMB_MODELSDIR"
-echo "ILAMB_OUTPUTDIR $ILAMB_OUTPUTDIR"
-echo "ILAMB_TMPDIR    $ILAMB_TMPDIR"
+echo "ILAMB files and directories:"
+echo "ILAMB_ROOT           $ILAMB_ROOT"
+echo "ILAMB_CODESDIR       $ILAMB_CODESDIR"
+echo "ILAMB_DATADIR        $ILAMB_DATADIR"
+echo "ILAMB_MODELSDIR      $ILAMB_MODELSDIR"
+echo "ILAMB_OUTPUTDIR      $ILAMB_OUTPUTDIR"
+echo "ILAMB_TMPDIR         $ILAMB_TMPDIR"
+echo "ILAMB parameter file $1"
 
 ## Define model simulation type, CLM or CMIP5.
 export MODELTYPE=CMIP5
@@ -34,5 +40,5 @@ export SPATRES=0.5x0.5
 export PLOTTYPE=png
 
 date
-ncl -n main_ncl_code.ncl
+ncl -n main_ncl_code.ncl ParameterFile=\"$1\"  # http://www.ncl.ucar.edu/Applications/system.shtml
 date

--- a/CODES/main_ncl_code.ncl
+++ b/CODES/main_ncl_code.ncl
@@ -11,6 +11,13 @@ loadscript ("$ILAMB_CODESDIR/subroutines/library/library.ncl")
 
 begin
 
+  ; Check that the user has included the path to the ILAMB parameter file.
+  if .not.isvar((/"ParameterFile"/)) then
+    print("Error: ParameterFile must be defined.")
+    status_exit(1)
+  end if
+  print(ParameterFile)
+
   ILAMBDir = getenv("ILAMB_ROOT")
 
   PlotType = getenv("PLOTTYPE")
@@ -28,8 +35,7 @@ begin
 
   nvpa = 0
   nchk = 0
-
-  VarNames = input_control_para (nvpa, nchk)
+  VarNames = input_control_para(nvpa, nchk, ParameterFile)
 
 ; +++++++++++ Run Global Variable diagnostics +++++++++++++
 

--- a/CODES/run_ilamb.sh
+++ b/CODES/run_ilamb.sh
@@ -6,19 +6,16 @@
 # ILAMB execution script adapted to run on `beach` through its queue
 # manager. Submit this script with:
 #
-#   $ qsub /home/csdms/tools/ILAMB/CODES/run_ilamb.sh -m ae -M <email>
+#   $ qsub -v parameter_file='/path/to/ILAMB_PARA_SETUP' \
+#   > /home/csdms/tools/ILAMB/CODES/run_ilamb.sh -m ae -M <email>
 #
 # The output from the ILAMB run is saved to a tarball in the user's
 # working directory, along with PBS output and error logs.
 
-# Define model simulation type, CLM or CMIP5.
-export MODELTYPE=CMIP5
-
-# Define spatial resolution for diagnostics, 0.5x0.5, 1x1 or 2.5x2.5.
-export SPATRES=0.5x0.5
-
-# Define plot file type: eps, pdf, png, or ps.
-export PLOTTYPE=png
+if [ -z "$parameter_file" ]; then
+    echo "Error: Must supply path to ILAMB parameter file"
+    exit 1
+fi
 
 # Define directories.
 tools_dir=/home/csdms/tools
@@ -43,13 +40,30 @@ export ILAMB_TMPDIR=$tmp_dir/tmp_$job_id
 stdout_file=$ILAMB_OUTPUTDIR/ILAMB.stdout
 stderr_file=$ILAMB_OUTPUTDIR/ILAMB.stderr
 
+# Define model simulation type, CLM or CMIP5.
+export MODELTYPE=CMIP5
+
+# Define spatial resolution for diagnostics, 0.5x0.5, 1x1 or 2.5x2.5.
+export SPATRES=0.5x0.5
+
+# Define plot file type: eps, pdf, png, or ps.
+export PLOTTYPE=png
+
 # Copy OUTPUT to tmp directory for job.
 cp -R $nas_dir/OUTPUT $ILAMB_OUTPUTDIR
 
 # Run ILAMB.
 cd $ILAMB_CODESDIR
+echo "ILAMB_ROOT           $ILAMB_ROOT"
+echo "ILAMB_CODESDIR       $ILAMB_CODESDIR"
+echo "ILAMB_DATADIR        $ILAMB_DATADIR"
+echo "ILAMB_MODELSDIR      $ILAMB_MODELSDIR"
+echo "ILAMB_OUTPUTDIR      $ILAMB_OUTPUTDIR"
+echo "ILAMB_TMPDIR         $ILAMB_TMPDIR"
+echo "ILAMB parameter file $parameter_file"
+echo "HOSTNAME             $HOSTNAME"
 echo "ILAMB start:" `date`
-ncl -n main_ncl_code.ncl 1> $stdout_file 2> $stderr_file
+ncl -n main_ncl_code.ncl ParameterFile=\"$parameter_file\" 1>$stdout_file 2>$stderr_file
 echo "ILAMB finish:" `date`
 
 # Package results.

--- a/CODES/subroutines/diagnostic/input_control_para.ncl
+++ b/CODES/subroutines/diagnostic/input_control_para.ncl
@@ -1,4 +1,4 @@
-function input_control_para (nvpa:integer, nchk:integer)
+function input_control_para (nvpa:integer, nchk:integer, ParameterFile:string)
 
 begin
 
@@ -75,7 +75,8 @@ end if
 ; +++++++ input control parameters from the file: ILAMB_PARA_SETUP +++++++
 
 ; ++++++++++ read all input parameters from the control file ++++++++++
-FileList = systemfunc ("ls " + getenv("ILAMB_CODESDIR") + "/INPUT/ILAMB_PARA_SETUP")
+; FileList = systemfunc ("ls " + getenv("ILAMB_CODESDIR") + "/INPUT/ILAMB_PARA_SETUP")
+FileList = ParameterFile
 
 if (fileexists(FileList)) then
 


### PR DESCRIPTION
ILAMB looks for its parameter file, **ILAMB_PARA_SETUP**, in its **CODES/INPUT** directory. However, as described in #2, concurrent users of ILAMB may clobber the others' input file. I've reconfigured the ILAMB code to accept the location of the ILAMB parameter file as a parameter (**input_control_para.ncl**) and as a command-line argument (**main_ncl_code.ncl**). I've also updated my testing and production scripts.

This fixes #2.
