### PR TITLE
Add MsTMIP as a model type

### DIFF
--- a/CODES/ILAMB_Main.sh
+++ b/CODES/ILAMB_Main.sh
@@ -34,7 +34,7 @@ tools_dir=/home/csdms/tools
 export NCARG_ROOT=$tools_dir/ncl
 PATH=$NCARG_ROOT/bin:$tools_dir/ImageMagick/bin:$PATH
 
-## Define model simulation type, CLM or CMIP5.
+## Define model simulation type, CLM, CMIP5, or MsTMIP.
 export MODELTYPE=CMIP5
 
 ## Define spatial resolution for diagnostics, 0.5x0.5, 1x1 or 2.5x2.5.

--- a/CODES/INPUT/retrieve_DataInfo.ncl
+++ b/CODES/INPUT/retrieve_DataInfo.ncl
@@ -519,12 +519,16 @@ begin
 
   if (str_lower(VarName).eq."nee") then
      LongName      = "Net Ecosystem Exchange"
-     VarModel      = "gpp"
      ModelComp     = "Lmon"    
      Category      = CatNames(0)
-     VarModelComb  = "YES"
-     GSMLocalRefer = "YES"
-     MassWeighting = "YES"
+     if (str_lower(ModelType).eq."mstmip") then
+        VarModel        = "nep"
+     else
+        VarModel        = "gpp"
+        VarModelComb    = "YES"
+     end if
+     GSMLocalRefer   = "YES"
+     MassWeighting   = "YES"
      MassWeightingFC = "YES"
      MinFC           = 1.2
      if (str_lower(Source).eq."fluxnet") then

--- a/CODES/INPUT/retrieve_DataInfo.ncl
+++ b/CODES/INPUT/retrieve_DataInfo.ncl
@@ -371,7 +371,12 @@ begin
 
   if (str_lower(VarName).eq."biomass") then
      LongName      = "Aboveground Live Biomass"
-     VarModel      = "cVeg"
+     ; VarModel      = "cVeg"
+     if (str_lower(ModelType).eq."mstmip") then
+        VarModel     = "cWood"
+     else
+        VarModel     = "cVeg"
+     end if
      ModelComp     = "Lmon"    
      Category      = CatNames(0)
      LandOnly      = "YES" 

--- a/CODES/run_ilamb.sh
+++ b/CODES/run_ilamb.sh
@@ -41,7 +41,7 @@ export ILAMB_TMPDIR=$tmp_dir/tmp_$job_id
 stdout_file=$ILAMB_OUTPUTDIR/ILAMB.stdout
 stderr_file=$ILAMB_OUTPUTDIR/ILAMB.stderr
 
-# Define model simulation type, CLM or CMIP5.
+# Define model simulation type, CLM, CMIP5, or MsTMIP.
 export MODELTYPE=CMIP5
 
 # Define spatial resolution for diagnostics, 0.5x0.5, 1x1 or 2.5x2.5.

--- a/scripts/ilamb-run
+++ b/scripts/ilamb-run
@@ -31,7 +31,7 @@ export ILAMB_TMPDIR=$work_dir/ILAMB-tmp
 stdout_file=$work_dir/ILAMB.stdout
 stderr_file=$work_dir/ILAMB.stderr
 
-# Define model simulation type, CLM or CMIP5.
+# Define model simulation type, CLM, CMIP5 or MsTMIP.
 export MODELTYPE=CMIP5
 
 # Define spatial resolution for diagnostics, 0.5x0.5, 1x1 or 2.5x2.5.


### PR DESCRIPTION
ILAMB uses the `MODELTYPE` environment variable to distinguish between CLM and CMIP5 models. I've added a new allowable value, `MsTMIP`, to configure ILAMB to use different outputs from the MsTMIP models.